### PR TITLE
Updated deploy action to use github pages

### DIFF
--- a/.github/workflows/deploy-action.yml
+++ b/.github/workflows/deploy-action.yml
@@ -3,26 +3,15 @@ on:
   push:
     branches:
       - "main"
-name: Deploy to EC2
+name: Deployment
 jobs:
   build:
+    name: shalzz/zola-deploy-action
     runs-on: ubuntu-latest
     steps:
-    # Followed this for ssh setup - https://zellwk.com/blog/github-actions-deploy/
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          known_hosts: "just-a-placeholder"
-      - name: Adding correct known_hosts
-        run: ssh-keyscan -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts
-      - name: Checkout code
-        uses: actions/checkout@master
-      - name: Install Zola
-        run: |
-          wget https://github.com/getzola/zola/releases/download/v0.14.1/zola-v0.14.1-x86_64-unknown-linux-gnu.tar.gz
-          tar -xzf zola-v0.14.1-x86_64-unknown-linux-gnu.tar.gz
-      - name: Build site
-        run: ./zola build
-      - name: Send public folder to EC2 instance
-        run: rsync -avz ./public/ ubuntu@${{ secrets.SSH_HOST }}:/home/ubuntu
+      - uses: actions/checkout@master
+      - name: shalzz/zola-deploy-action
+        uses: shalzz/zola-deploy-action@master
+        env:
+          PAGES_BRANCH: gh-pages
+          TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
## In this PR
- updated the action to build and use GitHub actions, why? because it's cheaper than an EC2 instance.